### PR TITLE
Add Capistrano task to upload gulp build files

### DIFF
--- a/app/config/capistrano/deploy.rb
+++ b/app/config/capistrano/deploy.rb
@@ -14,3 +14,12 @@ set :repo_url, "git@bitbucket.org:siesqo/???.git"
 set :deploytag_utc, false
 set :deploytag_time_format, "%Y%m%d-%H%M%S"
 set :files_dir, %w(src/Frontend/Files)
+
+## Gulp build our custom theme
+require 'json'
+namespace :deploy do
+  package = JSON.parse(File.read('composer.json'))
+
+  # compile and upload the assets, but only if it's a Fork CMS project
+  after :updated, 'siesqo:assets:put' if package['name'] == 'forkcms/forkcms'
+end

--- a/app/config/capistrano/tasks/assets.rake
+++ b/app/config/capistrano/tasks/assets.rake
@@ -1,0 +1,38 @@
+require 'json'
+
+namespace :siesqo do
+  namespace :assets do
+    desc 'Compile the assets'
+    task :compile do
+      run_locally do
+        execute :gulp, '--silent', 'build:theme'
+      end
+    end
+
+    desc 'Uploads the build assets to the remote server'
+    task :put do
+      invoke 'siesqo:assets:compile'
+      on roles(:web) do
+        remote_path = "#{release_path}/src/Frontend/Themes/#{theme}/Core"
+
+        # delete old folder
+        execute :rm, '-rf', remote_path
+        execute :mkdir, '-p', remote_path
+
+        # upload compiled theme
+        upload! "./src/Frontend/Themes/#{theme}/Core", "#{File.dirname(remote_path)}", recursive: true
+      end
+    end
+
+    def theme
+      package = JSON.parse(File.read('package.json'))
+
+      if not package.key?('theme')
+        warn Airbrussh::Colors.red('✘') + ' No theme available in package.json.'
+        exit 1
+      end
+
+      package['theme']
+    end
+  end
+end


### PR DESCRIPTION
## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Feature

## Pull request description
<!-- Describe what your pull request will fix / add / … -->
Add Capistrano task to upload gulp build files

We have a `src/Frontend/Themes/Triskel/src` folder.
`gulp build` builds this to `src/Frontend/Themes/Triskel/Core`.
This `Core` folder is not in our repo,
so when deploying we need to upload those files.
This is exactly what this new Capistrano task does.